### PR TITLE
Convert to double quotes when `strings.single_quote` is false

### DIFF
--- a/models/cfscript/Strings.cfc
+++ b/models/cfscript/Strings.cfc
@@ -22,6 +22,8 @@ component {
 
         if (element.type == 'string-double' && settings['strings.single_quote']) {
             quote = '''';
+        } else if (element.type == 'string-single' && !settings['strings.single_quote']) {
+            quote = '"';
         }
 
         var formatted = '';


### PR DESCRIPTION
If you don't like this option, perhaps we can introduce a `strings.quote` property that can be `double`, `single`, or `null`.