### PR TITLE
Settings wizard

### DIFF
--- a/ModuleConfig.cfc
+++ b/ModuleConfig.cfc
@@ -1,5 +1,6 @@
 component {
 
+    this.cfmapping = "cfformat";
     this.autoMapModels = false;
 
     function configure() {

--- a/build.cfc
+++ b/build.cfc
@@ -166,7 +166,7 @@ component accessors="true" {
         var examples = {};
         for (var setting in reference) {
             if (reference[setting].keyExists('example')) {
-                var output = [];
+                var output = {};
                 var values = reference[setting].example.keyExists('values') ? reference[setting].example.values : [];
                 if (reference[setting].keyExists('values')) {
                     values = reference[setting].values;
@@ -181,15 +181,13 @@ component accessors="true" {
                         tokens,
                         cfformat.mergedSettings(reference[setting].example.settings)
                     );
-                    output.append(
-                        formatted
-                            .replace(chr(13), '', 'all')
-                            .reReplace('//\s?', '// #setting#: #isNull(v) ? 'null' : serializeJSON(v)#')
-                            .trim()
-                    );
+                    output[ v ] = formatted
+                        .replace(chr(13), '', 'all')
+                        .reReplace('//\s?', '// #setting#: #isNull(v) ? 'null' : serializeJSON(v)#')
+                        .trim();
                 }
 
-                examples[setting] = output.toList(lf & lf);
+                examples[setting] = output;
             }
         }
 
@@ -227,7 +225,7 @@ component accessors="true" {
                 md &= lf & reference[setting].description & lf;
             }
             if (examples.keyExists(setting)) {
-                md &= lf & '```cfc' & lf & examples[setting] & lf & '```';
+                md &= lf & '```cfc' & lf & structValueArray( examples[setting] ).toList(lf & lf) & lf & '```';
             }
             markdown.append(md);
         }
@@ -257,6 +255,13 @@ component accessors="true" {
         if (filesystem.isWindows()) return 'cftokens.exe';
         if (filesystem.isMac()) return 'cftokens_osx';
         if (filesystem.isLinux()) return 'cftokens_linux';
+    }
+
+    private function structValueArray( required struct structure ) {
+        return arguments.structure.reduce( ( values, _, value ) => {
+            values.append( value );
+            return values;
+        }, [] );
     }
 
 }

--- a/build.cfc
+++ b/build.cfc
@@ -3,6 +3,8 @@ component accessors="true" {
     property tempDir inject="tempDir@constants";
     property filesystem inject="filesystem";
     property JSONService inject="JSONService";
+	property JSONPrettyPrint inject="provider:JSONPrettyPrint";
+
 
     function run() {
         syntect();
@@ -163,10 +165,10 @@ component accessors="true" {
 
         // generate examples
         var cfformat = new models.CFFormat('', dir);
-        var examples = {};
+        var examples = structNew( "ordered" );
         for (var setting in reference) {
             if (reference[setting].keyExists('example')) {
-                var output = {};
+                var output = structNew( "ordered" );
                 var values = reference[setting].example.keyExists('values') ? reference[setting].example.values : [];
                 if (reference[setting].keyExists('values')) {
                     values = reference[setting].values;
@@ -191,7 +193,10 @@ component accessors="true" {
             }
         }
 
-        JSONService.writeJSONFile(dir & 'data/examples.json', examples);
+        fileWrite(
+            dir & 'data/examples.json',
+            JSONPrettyPrint.formatJSON( examples )
+        );
     }
 
     function reference() {

--- a/commands/cfformat/settings/list.cfc
+++ b/commands/cfformat/settings/list.cfc
@@ -1,0 +1,7 @@
+component {
+
+    function run() {
+        //
+    }
+
+}

--- a/commands/cfformat/settings/list.cfc
+++ b/commands/cfformat/settings/list.cfc
@@ -1,7 +1,0 @@
-component {
-
-    function run() {
-        //
-    }
-
-}

--- a/commands/cfformat/settings/wizard.cfc
+++ b/commands/cfformat/settings/wizard.cfc
@@ -1,0 +1,54 @@
+component {
+
+    property name="fileSystemUtil" inject="FileSystem";
+    property name='formatterUtil' inject='formatter';
+
+    function run() {
+        var examples = deserializeJSON(
+            fileRead( expandPath( "/cfformat/data/examples.json" ) )
+        );
+
+        print.line();
+        print.line( "Let me help you get started with your cfformat settings." );
+        print.line( "I'll show you examples of each formatting option.  You choose the one you prefer." );
+        print.line( "At the end, I'll generate a `.cfformat.json` for your project." );
+        print.line( "Sound good?  Press any key to get started!" ).toConsole();
+        waitForKey();
+
+        var userSettings = examples.reduce( ( settings, name, options ) => {
+            shell.clearScreen();
+
+            print.blackOnYellowLine( name ).line();
+
+            options.each( ( option, example ) => {
+                print.underscoredBlueLine( option );
+                print.line( example )
+                print.line().toConsole();
+            } );
+
+            settings[ name ] = multiselect()
+                .setQuestion( "Which style do you prefer? " )
+                .setOptions(
+                    options.keyArray().map( ( option ) => ( { "value" = option } ) )
+                )
+                .setRequired( true )
+                .setMultiple( false )
+                .ask();
+
+            return settings;
+        }, [:] );
+
+        shell.clearScreen();
+        print.line( "Great! Let's save these settings off to a file." );
+        print.line( "Where should I save the file?" ).toConsole();
+        var filePath = ask( message = "", defaultResponse = ".cfformat.json" );
+
+        fileSystemUtil.lockingFileWrite(
+            fileSystemUtil.resolvePath( filePath ),
+            formatterUtil.formatJson( serializeJSON( userSettings ) )
+        );
+
+        print.line().boldDarkGreenOnWhiteLine( " All done!  Enjoy your automatically formatted life! " );
+    }
+
+}

--- a/data/examples.json
+++ b/data/examples.json
@@ -1,44 +1,182 @@
 {
-    "alignment.consecutive.assignments":"// alignment.consecutive.assignments: true\nvar a  = 1;\nvar ab = 2;\n\n// alignment.consecutive.assignments: false\nvar a = 1;\nvar ab = 2;",
-    "alignment.consecutive.params":"// alignment.consecutive.params: true\nparam name=\"a\"       type=\"string\";\nparam name=\"abcdefg\" type=\"string\";\n\n// alignment.consecutive.params: false\nparam name=\"a\" type=\"string\";\nparam name=\"abcdefg\" type=\"string\";",
-    "alignment.consecutive.properties":"// alignment.consecutive.properties: true\nproperty name=\"requestService\" inject=\"coldbox:requestService\";\nproperty name=\"log\"            inject=\"logbox:logger:{this}\";\n\n// alignment.consecutive.properties: false\nproperty name=\"requestService\" inject=\"coldbox:requestService\";\nproperty name=\"log\" inject=\"logbox:logger:{this}\";",
-    "array.empty_padding":"// array.empty_padding: true\nmyArray = [ ];\n\n// array.empty_padding: false\nmyArray = [];",
-    "array.multiline.leading_comma":"// array.multiline.leading_comma: true\nmyArray = [\n      1\n    , 2\n    , 3\n    , 4\n];\n\n// array.multiline.leading_comma: false\nmyArray = [\n    1,\n    2,\n    3,\n    4\n];",
-    "array.multiline.leading_comma.padding":"// array.multiline.leading_comma.padding: true\nmyArray = [\n      1\n    , 2\n    , 3\n    , 4\n];\n\n// array.multiline.leading_comma.padding: false\nmyArray = [\n     1\n    ,2\n    ,3\n    ,4\n];",
-    "array.padding":"// array.padding: true\nmyArray = [ 1, 2 ];\n\n// array.padding: false\nmyArray = [1, 2];",
-    "binary_operators.padding":"// binary_operators.padding: true\na = 1 + 2;\n\n// binary_operators.padding: false\na=1+2;",
-    "brackets.padding":"// brackets.padding: true\na[ 'mykey' ][ 1 ] = 7;\n\n// brackets.padding: false\na['mykey'][1] = 7;",
-    "comment.asterisks":"// comment.asterisks: \"align\"\n{\n    /**\n     * a comment\n     */\n}\n\n// comment.asterisks: \"indent\"\n{\n    /**\n    * a comment\n    */\n}\n\n// comment.asterisks: \"\"\n{\n    /**\n      * a comment\n    */\n}",
-    "for_loop_semicolons.padding":"// for_loop_semicolons.padding: true\nfor (var i = 0; i < 10; i++) {\n}\n\n// for_loop_semicolons.padding: false\nfor (var i = 0;i < 10;i++) {\n}",
-    "function_anonymous.empty_padding":"// function_anonymous.empty_padding: true\nfunction( ) {\n}\n\n// function_anonymous.empty_padding: false\nfunction() {\n}",
-    "function_anonymous.group_to_block_spacing":"// function_anonymous.group_to_block_spacing: \"spaced\"\nfunction() {\n}\n\n// function_anonymous.group_to_block_spacing: \"compact\"\nfunction(){\n}\n\n// function_anonymous.group_to_block_spacing: \"newline\"\nfunction()\n{\n}",
-    "function_anonymous.multiline.leading_comma":"// function_anonymous.multiline.leading_comma: true\nfunction(\n      a\n    , b\n    , c\n    , d\n) {\n}\n\n// function_anonymous.multiline.leading_comma: false\nfunction(\n    a,\n    b,\n    c,\n    d\n) {\n}",
-    "function_anonymous.multiline.leading_comma.padding":"// function_anonymous.multiline.leading_comma.padding: true\nfunction(\n      a\n    , b\n    , c\n    , d\n) {\n}\n\n// function_anonymous.multiline.leading_comma.padding: false\nfunction(\n     a\n    ,b\n    ,c\n    ,d\n) {\n}",
-    "function_anonymous.padding":"// function_anonymous.padding: true\nfunction( a, b ) {\n}\n\n// function_anonymous.padding: false\nfunction(a, b) {\n}",
-    "function_call.casing.builtin":"// function_call.casing.builtin: \"cfdocs\"\narrayAppend(myarray, 1);\n\n// function_call.casing.builtin: \"pascal\"\nArrayAppend(myarray, 1);\n\n// function_call.casing.builtin: \"\"\nARRAYAPPEND(myarray, 1);",
-    "function_call.casing.userdefined":"// function_call.casing.userdefined: \"\"\nmyFunc();\n\n// function_call.casing.userdefined: \"camel\"\nmyFunc();\n\n// function_call.casing.userdefined: \"pascal\"\nMyFunc();",
-    "function_call.empty_padding":"// function_call.empty_padding: true\nmyFunc( );\n\n// function_call.empty_padding: false\nmyFunc();",
-    "function_call.multiline.leading_comma":"// function_call.multiline.leading_comma: true\nmyFunc(\n      1\n    , 2\n    , 3\n    , 4\n);\n\n// function_call.multiline.leading_comma: false\nmyFunc(\n    1,\n    2,\n    3,\n    4\n);",
-    "function_call.multiline.leading_comma.padding":"// function_call.multiline.leading_comma.padding: true\nmyFunc(\n      1\n    , 2\n    , 3\n    , 4\n);\n\n// function_call.multiline.leading_comma.padding: false\nmyFunc(\n     1\n    ,2\n    ,3\n    ,4\n);",
-    "function_call.padding":"// function_call.padding: true\nmyFunc( 1, 2 );\n\n// function_call.padding: false\nmyFunc(1, 2);",
-    "function_declaration.empty_padding":"// function_declaration.empty_padding: true\nfunction example( ) {\n}\n\n// function_declaration.empty_padding: false\nfunction example() {\n}",
-    "function_declaration.group_to_block_spacing":"// function_declaration.group_to_block_spacing: \"spaced\"\nfunction example() {\n}\n\n// function_declaration.group_to_block_spacing: \"compact\"\nfunction example(){\n}\n\n// function_declaration.group_to_block_spacing: \"newline\"\nfunction example()\n{\n}",
-    "function_declaration.multiline.leading_comma":"// function_declaration.multiline.leading_comma: true\nfunction example(\n      a\n    , b\n    , c\n    , d\n) {\n}\n\n// function_declaration.multiline.leading_comma: false\nfunction example(\n    a,\n    b,\n    c,\n    d\n) {\n}",
-    "function_declaration.multiline.leading_comma.padding":"// function_declaration.multiline.leading_comma.padding: true\nfunction example(\n      a\n    , b\n    , c\n    , d\n) {\n}\n\n// function_declaration.multiline.leading_comma.padding: false\nfunction example(\n     a\n    ,b\n    ,c\n    ,d\n) {\n}",
-    "function_declaration.padding":"// function_declaration.padding: true\nfunction example( a, b ) {\n}\n\n// function_declaration.padding: false\nfunction example(a, b) {\n}",
-    "indent_size":"// indent_size: 4\ndo {\n    myFunc();\n}\n\n// indent_size: 2\ndo {\n  myFunc();\n}",
-    "keywords.block_to_keyword_spacing":"// keywords.block_to_keyword_spacing: \"spaced\"\nif (true) {\n} else {\n}\n\n// keywords.block_to_keyword_spacing: \"compact\"\nif (true) {\n}else {\n}\n\n// keywords.block_to_keyword_spacing: \"newline\"\nif (true) {\n}\nelse {\n}",
-    "keywords.empty_group_spacing":"// keywords.empty_group_spacing: true\nif ( ) {\n}\n\n// keywords.empty_group_spacing: false\nif () {\n}",
-    "keywords.group_to_block_spacing":"// keywords.group_to_block_spacing: \"spaced\"\nif (true) {\n}\n\n// keywords.group_to_block_spacing: \"compact\"\nif (true){\n}\n\n// keywords.group_to_block_spacing: \"newline\"\nif (true)\n{\n}",
-    "keywords.padding_inside_group":"// keywords.padding_inside_group: true\nif ( true ) {\n}\n\n// keywords.padding_inside_group: false\nif (true) {\n}",
-    "keywords.spacing_to_block":"// keywords.spacing_to_block: \"spaced\"\ndo {\n}\n\n// keywords.spacing_to_block: \"compact\"\ndo{\n}\n\n// keywords.spacing_to_block: \"newline\"\ndo\n{\n}",
-    "keywords.spacing_to_group":"// keywords.spacing_to_group: true\nif (true) {\n}\n\n// keywords.spacing_to_group: false\nif(true) {\n}",
-    "parentheses.padding":"// parentheses.padding: true\na = ( 1 + 2 );\n\n// parentheses.padding: false\na = (1 + 2);",
-    "strings.attributes.quote":"// strings.attributes.quote: \"single\"\nhttp url='www.google.com';\nparam name='key';\n\n// strings.attributes.quote: \"double\"\nhttp url=\"www.google.com\";\nparam name=\"key\";\n\n// strings.attributes.quote: \"\"\nhttp url='www.google.com';\nparam name=\"key\";",
-    "strings.quote":"// strings.quote: \"single\"\na = 'One';\nb = 'Two';\n\n// strings.quote: \"double\"\na = \"One\";\nb = \"Two\";\n\n// strings.quote: \"\"\na = \"One\";\nb = 'Two';",
-    "struct.empty_padding":"// struct.empty_padding: true\nmyStruct = { };\n\n// struct.empty_padding: false\nmyStruct = {};",
-    "struct.multiline.leading_comma":"// struct.multiline.leading_comma: true\nmyStruct = {\n      a: 1\n    , b: 2\n    , c: 3\n    , d: 4\n};\n\n// struct.multiline.leading_comma: false\nmyStruct = {\n    a: 1,\n    b: 2,\n    c: 3,\n    d: 4\n};",
-    "struct.multiline.leading_comma.padding":"// struct.multiline.leading_comma.padding: true\nmyStruct = {\n      a: 1\n    , b: 2\n    , c: 3\n    , d: 4\n};\n\n// struct.multiline.leading_comma.padding: false\nmyStruct = {\n     a: 1\n    ,b: 2\n    ,c: 3\n    ,d: 4\n};",
-    "struct.padding":"// struct.padding: true\nmyStruct = { a: 1, b: 2 };\n\n// struct.padding: false\nmyStruct = {a: 1, b: 2};",
-    "struct.separator":"// struct.separator: \": \"\nmyStruct = {a: 1, b: 2};\n\n// struct.separator: \" = \"\nmyStruct = {a = 1, b = 2};\n\n// struct.separator: \" : \"\nmyStruct = {a : 1, b : 2};\n\n// struct.separator: \"=\"\nmyStruct = {a=1, b=2};"
+    "alignment.consecutive.assignments":{
+        "false":"// alignment.consecutive.assignments: false\nvar a = 1;\nvar ab = 2;",
+        "true":"// alignment.consecutive.assignments: true\nvar a  = 1;\nvar ab = 2;"
+    },
+    "alignment.consecutive.params":{
+        "false":"// alignment.consecutive.params: false\nparam name=\"a\" type=\"string\";\nparam name=\"abcdefg\" type=\"string\";",
+        "true":"// alignment.consecutive.params: true\nparam name=\"a\"       type=\"string\";\nparam name=\"abcdefg\" type=\"string\";"
+    },
+    "alignment.consecutive.properties":{
+        "false":"// alignment.consecutive.properties: false\nproperty name=\"requestService\" inject=\"coldbox:requestService\";\nproperty name=\"log\" inject=\"logbox:logger:{this}\";",
+        "true":"// alignment.consecutive.properties: true\nproperty name=\"requestService\" inject=\"coldbox:requestService\";\nproperty name=\"log\"            inject=\"logbox:logger:{this}\";"
+    },
+    "array.empty_padding":{
+        "false":"// array.empty_padding: false\nmyArray = [];",
+        "true":"// array.empty_padding: true\nmyArray = [ ];"
+    },
+    "array.multiline.leading_comma":{
+        "false":"// array.multiline.leading_comma: false\nmyArray = [\n    1,\n    2,\n    3,\n    4\n];",
+        "true":"// array.multiline.leading_comma: true\nmyArray = [\n      1\n    , 2\n    , 3\n    , 4\n];"
+    },
+    "array.multiline.leading_comma.padding":{
+        "false":"// array.multiline.leading_comma.padding: false\nmyArray = [\n     1\n    ,2\n    ,3\n    ,4\n];",
+        "true":"// array.multiline.leading_comma.padding: true\nmyArray = [\n      1\n    , 2\n    , 3\n    , 4\n];"
+    },
+    "array.padding":{
+        "false":"// array.padding: false\nmyArray = [1, 2];",
+        "true":"// array.padding: true\nmyArray = [ 1, 2 ];"
+    },
+    "binary_operators.padding":{
+        "false":"// binary_operators.padding: false\na=1+2;",
+        "true":"// binary_operators.padding: true\na = 1 + 2;"
+    },
+    "brackets.padding":{
+        "false":"// brackets.padding: false\na['mykey'][1] = 7;",
+        "true":"// brackets.padding: true\na[ 'mykey' ][ 1 ] = 7;"
+    },
+    "comment.asterisks":{
+        "":"// comment.asterisks: \"\"\n{\n    /**\n      * a comment\n    */\n}",
+        "align":"// comment.asterisks: \"align\"\n{\n    /**\n     * a comment\n     */\n}",
+        "indent":"// comment.asterisks: \"indent\"\n{\n    /**\n    * a comment\n    */\n}"
+    },
+    "for_loop_semicolons.padding":{
+        "false":"// for_loop_semicolons.padding: false\nfor (var i = 0;i < 10;i++) {\n}",
+        "true":"// for_loop_semicolons.padding: true\nfor (var i = 0; i < 10; i++) {\n}"
+    },
+    "function_anonymous.empty_padding":{
+        "false":"// function_anonymous.empty_padding: false\nfunction() {\n}",
+        "true":"// function_anonymous.empty_padding: true\nfunction( ) {\n}"
+    },
+    "function_anonymous.group_to_block_spacing":{
+        "compact":"// function_anonymous.group_to_block_spacing: \"compact\"\nfunction(){\n}",
+        "newline":"// function_anonymous.group_to_block_spacing: \"newline\"\nfunction()\n{\n}",
+        "spaced":"// function_anonymous.group_to_block_spacing: \"spaced\"\nfunction() {\n}"
+    },
+    "function_anonymous.multiline.leading_comma":{
+        "false":"// function_anonymous.multiline.leading_comma: false\nfunction(\n    a,\n    b,\n    c,\n    d\n) {\n}",
+        "true":"// function_anonymous.multiline.leading_comma: true\nfunction(\n      a\n    , b\n    , c\n    , d\n) {\n}"
+    },
+    "function_anonymous.multiline.leading_comma.padding":{
+        "false":"// function_anonymous.multiline.leading_comma.padding: false\nfunction(\n     a\n    ,b\n    ,c\n    ,d\n) {\n}",
+        "true":"// function_anonymous.multiline.leading_comma.padding: true\nfunction(\n      a\n    , b\n    , c\n    , d\n) {\n}"
+    },
+    "function_anonymous.padding":{
+        "false":"// function_anonymous.padding: false\nfunction(a, b) {\n}",
+        "true":"// function_anonymous.padding: true\nfunction( a, b ) {\n}"
+    },
+    "function_call.casing.builtin":{
+        "":"// function_call.casing.builtin: \"\"\nARRAYAPPEND(myarray, 1);",
+        "cfdocs":"// function_call.casing.builtin: \"cfdocs\"\narrayAppend(myarray, 1);",
+        "pascal":"// function_call.casing.builtin: \"pascal\"\nArrayAppend(myarray, 1);"
+    },
+    "function_call.casing.userdefined":{
+        "":"// function_call.casing.userdefined: \"\"\nmyFunc();",
+        "camel":"// function_call.casing.userdefined: \"camel\"\nmyFunc();",
+        "pascal":"// function_call.casing.userdefined: \"pascal\"\nMyFunc();"
+    },
+    "function_call.empty_padding":{
+        "false":"// function_call.empty_padding: false\nmyFunc();",
+        "true":"// function_call.empty_padding: true\nmyFunc( );"
+    },
+    "function_call.multiline.leading_comma":{
+        "false":"// function_call.multiline.leading_comma: false\nmyFunc(\n    1,\n    2,\n    3,\n    4\n);",
+        "true":"// function_call.multiline.leading_comma: true\nmyFunc(\n      1\n    , 2\n    , 3\n    , 4\n);"
+    },
+    "function_call.multiline.leading_comma.padding":{
+        "false":"// function_call.multiline.leading_comma.padding: false\nmyFunc(\n     1\n    ,2\n    ,3\n    ,4\n);",
+        "true":"// function_call.multiline.leading_comma.padding: true\nmyFunc(\n      1\n    , 2\n    , 3\n    , 4\n);"
+    },
+    "function_call.padding":{
+        "false":"// function_call.padding: false\nmyFunc(1, 2);",
+        "true":"// function_call.padding: true\nmyFunc( 1, 2 );"
+    },
+    "function_declaration.empty_padding":{
+        "false":"// function_declaration.empty_padding: false\nfunction example() {\n}",
+        "true":"// function_declaration.empty_padding: true\nfunction example( ) {\n}"
+    },
+    "function_declaration.group_to_block_spacing":{
+        "compact":"// function_declaration.group_to_block_spacing: \"compact\"\nfunction example(){\n}",
+        "newline":"// function_declaration.group_to_block_spacing: \"newline\"\nfunction example()\n{\n}",
+        "spaced":"// function_declaration.group_to_block_spacing: \"spaced\"\nfunction example() {\n}"
+    },
+    "function_declaration.multiline.leading_comma":{
+        "false":"// function_declaration.multiline.leading_comma: false\nfunction example(\n    a,\n    b,\n    c,\n    d\n) {\n}",
+        "true":"// function_declaration.multiline.leading_comma: true\nfunction example(\n      a\n    , b\n    , c\n    , d\n) {\n}"
+    },
+    "function_declaration.multiline.leading_comma.padding":{
+        "false":"// function_declaration.multiline.leading_comma.padding: false\nfunction example(\n     a\n    ,b\n    ,c\n    ,d\n) {\n}",
+        "true":"// function_declaration.multiline.leading_comma.padding: true\nfunction example(\n      a\n    , b\n    , c\n    , d\n) {\n}"
+    },
+    "function_declaration.padding":{
+        "false":"// function_declaration.padding: false\nfunction example(a, b) {\n}",
+        "true":"// function_declaration.padding: true\nfunction example( a, b ) {\n}"
+    },
+    "indent_size":{
+        "2":"// indent_size: 2\ndo {\n  myFunc();\n}",
+        "4":"// indent_size: 4\ndo {\n    myFunc();\n}"
+    },
+    "keywords.block_to_keyword_spacing":{
+        "compact":"// keywords.block_to_keyword_spacing: \"compact\"\nif (true) {\n}else {\n}",
+        "newline":"// keywords.block_to_keyword_spacing: \"newline\"\nif (true) {\n}\nelse {\n}",
+        "spaced":"// keywords.block_to_keyword_spacing: \"spaced\"\nif (true) {\n} else {\n}"
+    },
+    "keywords.empty_group_spacing":{
+        "false":"// keywords.empty_group_spacing: false\nif () {\n}",
+        "true":"// keywords.empty_group_spacing: true\nif ( ) {\n}"
+    },
+    "keywords.group_to_block_spacing":{
+        "compact":"// keywords.group_to_block_spacing: \"compact\"\nif (true){\n}",
+        "newline":"// keywords.group_to_block_spacing: \"newline\"\nif (true)\n{\n}",
+        "spaced":"// keywords.group_to_block_spacing: \"spaced\"\nif (true) {\n}"
+    },
+    "keywords.padding_inside_group":{
+        "false":"// keywords.padding_inside_group: false\nif (true) {\n}",
+        "true":"// keywords.padding_inside_group: true\nif ( true ) {\n}"
+    },
+    "keywords.spacing_to_block":{
+        "compact":"// keywords.spacing_to_block: \"compact\"\ndo{\n}",
+        "newline":"// keywords.spacing_to_block: \"newline\"\ndo\n{\n}",
+        "spaced":"// keywords.spacing_to_block: \"spaced\"\ndo {\n}"
+    },
+    "keywords.spacing_to_group":{
+        "false":"// keywords.spacing_to_group: false\nif(true) {\n}",
+        "true":"// keywords.spacing_to_group: true\nif (true) {\n}"
+    },
+    "parentheses.padding":{
+        "false":"// parentheses.padding: false\na = (1 + 2);",
+        "true":"// parentheses.padding: true\na = ( 1 + 2 );"
+    },
+    "strings.attributes.quote":{
+        "":"// strings.attributes.quote: \"\"\nhttp url='www.google.com';\nparam name=\"key\";",
+        "double":"// strings.attributes.quote: \"double\"\nhttp url=\"www.google.com\";\nparam name=\"key\";",
+        "single":"// strings.attributes.quote: \"single\"\nhttp url='www.google.com';\nparam name='key';"
+    },
+    "strings.quote":{
+        "":"// strings.quote: \"\"\na = \"One\";\nb = 'Two';",
+        "double":"// strings.quote: \"double\"\na = \"One\";\nb = \"Two\";",
+        "single":"// strings.quote: \"single\"\na = 'One';\nb = 'Two';"
+    },
+    "struct.empty_padding":{
+        "false":"// struct.empty_padding: false\nmyStruct = {};",
+        "true":"// struct.empty_padding: true\nmyStruct = { };"
+    },
+    "struct.multiline.leading_comma":{
+        "false":"// struct.multiline.leading_comma: false\nmyStruct = {\n    a: 1,\n    b: 2,\n    c: 3,\n    d: 4\n};",
+        "true":"// struct.multiline.leading_comma: true\nmyStruct = {\n      a: 1\n    , b: 2\n    , c: 3\n    , d: 4\n};"
+    },
+    "struct.multiline.leading_comma.padding":{
+        "false":"// struct.multiline.leading_comma.padding: false\nmyStruct = {\n     a: 1\n    ,b: 2\n    ,c: 3\n    ,d: 4\n};",
+        "true":"// struct.multiline.leading_comma.padding: true\nmyStruct = {\n      a: 1\n    , b: 2\n    , c: 3\n    , d: 4\n};"
+    },
+    "struct.padding":{
+        "false":"// struct.padding: false\nmyStruct = {a: 1, b: 2};",
+        "true":"// struct.padding: true\nmyStruct = { a: 1, b: 2 };"
+    },
+    "struct.separator":{
+        " : ":"// struct.separator: \" : \"\nmyStruct = {a : 1, b : 2};",
+        " = ":"// struct.separator: \" = \"\nmyStruct = {a = 1, b = 2};",
+        ": ":"// struct.separator: \": \"\nmyStruct = {a: 1, b: 2};",
+        "=":"// struct.separator: \"=\"\nmyStruct = {a=1, b=2};"
+    }
 }

--- a/data/examples.json
+++ b/data/examples.json
@@ -1,74 +1,74 @@
 {
     "alignment.consecutive.assignments":{
-        "false":"// alignment.consecutive.assignments: false\nvar a = 1;\nvar ab = 2;",
-        "true":"// alignment.consecutive.assignments: true\nvar a  = 1;\nvar ab = 2;"
+        "true":"// alignment.consecutive.assignments: true\nvar a  = 1;\nvar ab = 2;",
+        "false":"// alignment.consecutive.assignments: false\nvar a = 1;\nvar ab = 2;"
     },
     "alignment.consecutive.params":{
-        "false":"// alignment.consecutive.params: false\nparam name=\"a\" type=\"string\";\nparam name=\"abcdefg\" type=\"string\";",
-        "true":"// alignment.consecutive.params: true\nparam name=\"a\"       type=\"string\";\nparam name=\"abcdefg\" type=\"string\";"
+        "true":"// alignment.consecutive.params: true\nparam name=\"a\"       type=\"string\";\nparam name=\"abcdefg\" type=\"string\";",
+        "false":"// alignment.consecutive.params: false\nparam name=\"a\" type=\"string\";\nparam name=\"abcdefg\" type=\"string\";"
     },
     "alignment.consecutive.properties":{
-        "false":"// alignment.consecutive.properties: false\nproperty name=\"requestService\" inject=\"coldbox:requestService\";\nproperty name=\"log\" inject=\"logbox:logger:{this}\";",
-        "true":"// alignment.consecutive.properties: true\nproperty name=\"requestService\" inject=\"coldbox:requestService\";\nproperty name=\"log\"            inject=\"logbox:logger:{this}\";"
+        "true":"// alignment.consecutive.properties: true\nproperty name=\"requestService\" inject=\"coldbox:requestService\";\nproperty name=\"log\"            inject=\"logbox:logger:{this}\";",
+        "false":"// alignment.consecutive.properties: false\nproperty name=\"requestService\" inject=\"coldbox:requestService\";\nproperty name=\"log\" inject=\"logbox:logger:{this}\";"
     },
     "array.empty_padding":{
-        "false":"// array.empty_padding: false\nmyArray = [];",
-        "true":"// array.empty_padding: true\nmyArray = [ ];"
+        "true":"// array.empty_padding: true\nmyArray = [ ];",
+        "false":"// array.empty_padding: false\nmyArray = [];"
     },
     "array.multiline.leading_comma":{
-        "false":"// array.multiline.leading_comma: false\nmyArray = [\n    1,\n    2,\n    3,\n    4\n];",
-        "true":"// array.multiline.leading_comma: true\nmyArray = [\n      1\n    , 2\n    , 3\n    , 4\n];"
+        "true":"// array.multiline.leading_comma: true\nmyArray = [\n      1\n    , 2\n    , 3\n    , 4\n];",
+        "false":"// array.multiline.leading_comma: false\nmyArray = [\n    1,\n    2,\n    3,\n    4\n];"
     },
     "array.multiline.leading_comma.padding":{
-        "false":"// array.multiline.leading_comma.padding: false\nmyArray = [\n     1\n    ,2\n    ,3\n    ,4\n];",
-        "true":"// array.multiline.leading_comma.padding: true\nmyArray = [\n      1\n    , 2\n    , 3\n    , 4\n];"
+        "true":"// array.multiline.leading_comma.padding: true\nmyArray = [\n      1\n    , 2\n    , 3\n    , 4\n];",
+        "false":"// array.multiline.leading_comma.padding: false\nmyArray = [\n     1\n    ,2\n    ,3\n    ,4\n];"
     },
     "array.padding":{
-        "false":"// array.padding: false\nmyArray = [1, 2];",
-        "true":"// array.padding: true\nmyArray = [ 1, 2 ];"
+        "true":"// array.padding: true\nmyArray = [ 1, 2 ];",
+        "false":"// array.padding: false\nmyArray = [1, 2];"
     },
     "binary_operators.padding":{
-        "false":"// binary_operators.padding: false\na=1+2;",
-        "true":"// binary_operators.padding: true\na = 1 + 2;"
+        "true":"// binary_operators.padding: true\na = 1 + 2;",
+        "false":"// binary_operators.padding: false\na=1+2;"
     },
     "brackets.padding":{
-        "false":"// brackets.padding: false\na['mykey'][1] = 7;",
-        "true":"// brackets.padding: true\na[ 'mykey' ][ 1 ] = 7;"
+        "true":"// brackets.padding: true\na[ 'mykey' ][ 1 ] = 7;",
+        "false":"// brackets.padding: false\na['mykey'][1] = 7;"
     },
     "comment.asterisks":{
-        "":"// comment.asterisks: \"\"\n{\n    /**\n      * a comment\n    */\n}",
         "align":"// comment.asterisks: \"align\"\n{\n    /**\n     * a comment\n     */\n}",
-        "indent":"// comment.asterisks: \"indent\"\n{\n    /**\n    * a comment\n    */\n}"
+        "indent":"// comment.asterisks: \"indent\"\n{\n    /**\n    * a comment\n    */\n}",
+        "":"// comment.asterisks: \"\"\n{\n    /**\n      * a comment\n    */\n}"
     },
     "for_loop_semicolons.padding":{
-        "false":"// for_loop_semicolons.padding: false\nfor (var i = 0;i < 10;i++) {\n}",
-        "true":"// for_loop_semicolons.padding: true\nfor (var i = 0; i < 10; i++) {\n}"
+        "true":"// for_loop_semicolons.padding: true\nfor (var i = 0; i < 10; i++) {\n}",
+        "false":"// for_loop_semicolons.padding: false\nfor (var i = 0;i < 10;i++) {\n}"
     },
     "function_anonymous.empty_padding":{
-        "false":"// function_anonymous.empty_padding: false\nfunction() {\n}",
-        "true":"// function_anonymous.empty_padding: true\nfunction( ) {\n}"
+        "true":"// function_anonymous.empty_padding: true\nfunction( ) {\n}",
+        "false":"// function_anonymous.empty_padding: false\nfunction() {\n}"
     },
     "function_anonymous.group_to_block_spacing":{
+        "spaced":"// function_anonymous.group_to_block_spacing: \"spaced\"\nfunction() {\n}",
         "compact":"// function_anonymous.group_to_block_spacing: \"compact\"\nfunction(){\n}",
-        "newline":"// function_anonymous.group_to_block_spacing: \"newline\"\nfunction()\n{\n}",
-        "spaced":"// function_anonymous.group_to_block_spacing: \"spaced\"\nfunction() {\n}"
+        "newline":"// function_anonymous.group_to_block_spacing: \"newline\"\nfunction()\n{\n}"
     },
     "function_anonymous.multiline.leading_comma":{
-        "false":"// function_anonymous.multiline.leading_comma: false\nfunction(\n    a,\n    b,\n    c,\n    d\n) {\n}",
-        "true":"// function_anonymous.multiline.leading_comma: true\nfunction(\n      a\n    , b\n    , c\n    , d\n) {\n}"
+        "true":"// function_anonymous.multiline.leading_comma: true\nfunction(\n      a\n    , b\n    , c\n    , d\n) {\n}",
+        "false":"// function_anonymous.multiline.leading_comma: false\nfunction(\n    a,\n    b,\n    c,\n    d\n) {\n}"
     },
     "function_anonymous.multiline.leading_comma.padding":{
-        "false":"// function_anonymous.multiline.leading_comma.padding: false\nfunction(\n     a\n    ,b\n    ,c\n    ,d\n) {\n}",
-        "true":"// function_anonymous.multiline.leading_comma.padding: true\nfunction(\n      a\n    , b\n    , c\n    , d\n) {\n}"
+        "true":"// function_anonymous.multiline.leading_comma.padding: true\nfunction(\n      a\n    , b\n    , c\n    , d\n) {\n}",
+        "false":"// function_anonymous.multiline.leading_comma.padding: false\nfunction(\n     a\n    ,b\n    ,c\n    ,d\n) {\n}"
     },
     "function_anonymous.padding":{
-        "false":"// function_anonymous.padding: false\nfunction(a, b) {\n}",
-        "true":"// function_anonymous.padding: true\nfunction( a, b ) {\n}"
+        "true":"// function_anonymous.padding: true\nfunction( a, b ) {\n}",
+        "false":"// function_anonymous.padding: false\nfunction(a, b) {\n}"
     },
     "function_call.casing.builtin":{
-        "":"// function_call.casing.builtin: \"\"\nARRAYAPPEND(myarray, 1);",
         "cfdocs":"// function_call.casing.builtin: \"cfdocs\"\narrayAppend(myarray, 1);",
-        "pascal":"// function_call.casing.builtin: \"pascal\"\nArrayAppend(myarray, 1);"
+        "pascal":"// function_call.casing.builtin: \"pascal\"\nArrayAppend(myarray, 1);",
+        "":"// function_call.casing.builtin: \"\"\nARRAYAPPEND(myarray, 1);"
     },
     "function_call.casing.userdefined":{
         "":"// function_call.casing.userdefined: \"\"\nmyFunc();",
@@ -76,107 +76,107 @@
         "pascal":"// function_call.casing.userdefined: \"pascal\"\nMyFunc();"
     },
     "function_call.empty_padding":{
-        "false":"// function_call.empty_padding: false\nmyFunc();",
-        "true":"// function_call.empty_padding: true\nmyFunc( );"
+        "true":"// function_call.empty_padding: true\nmyFunc( );",
+        "false":"// function_call.empty_padding: false\nmyFunc();"
     },
     "function_call.multiline.leading_comma":{
-        "false":"// function_call.multiline.leading_comma: false\nmyFunc(\n    1,\n    2,\n    3,\n    4\n);",
-        "true":"// function_call.multiline.leading_comma: true\nmyFunc(\n      1\n    , 2\n    , 3\n    , 4\n);"
+        "true":"// function_call.multiline.leading_comma: true\nmyFunc(\n      1\n    , 2\n    , 3\n    , 4\n);",
+        "false":"// function_call.multiline.leading_comma: false\nmyFunc(\n    1,\n    2,\n    3,\n    4\n);"
     },
     "function_call.multiline.leading_comma.padding":{
-        "false":"// function_call.multiline.leading_comma.padding: false\nmyFunc(\n     1\n    ,2\n    ,3\n    ,4\n);",
-        "true":"// function_call.multiline.leading_comma.padding: true\nmyFunc(\n      1\n    , 2\n    , 3\n    , 4\n);"
+        "true":"// function_call.multiline.leading_comma.padding: true\nmyFunc(\n      1\n    , 2\n    , 3\n    , 4\n);",
+        "false":"// function_call.multiline.leading_comma.padding: false\nmyFunc(\n     1\n    ,2\n    ,3\n    ,4\n);"
     },
     "function_call.padding":{
-        "false":"// function_call.padding: false\nmyFunc(1, 2);",
-        "true":"// function_call.padding: true\nmyFunc( 1, 2 );"
+        "true":"// function_call.padding: true\nmyFunc( 1, 2 );",
+        "false":"// function_call.padding: false\nmyFunc(1, 2);"
     },
     "function_declaration.empty_padding":{
-        "false":"// function_declaration.empty_padding: false\nfunction example() {\n}",
-        "true":"// function_declaration.empty_padding: true\nfunction example( ) {\n}"
+        "true":"// function_declaration.empty_padding: true\nfunction example( ) {\n}",
+        "false":"// function_declaration.empty_padding: false\nfunction example() {\n}"
     },
     "function_declaration.group_to_block_spacing":{
+        "spaced":"// function_declaration.group_to_block_spacing: \"spaced\"\nfunction example() {\n}",
         "compact":"// function_declaration.group_to_block_spacing: \"compact\"\nfunction example(){\n}",
-        "newline":"// function_declaration.group_to_block_spacing: \"newline\"\nfunction example()\n{\n}",
-        "spaced":"// function_declaration.group_to_block_spacing: \"spaced\"\nfunction example() {\n}"
+        "newline":"// function_declaration.group_to_block_spacing: \"newline\"\nfunction example()\n{\n}"
     },
     "function_declaration.multiline.leading_comma":{
-        "false":"// function_declaration.multiline.leading_comma: false\nfunction example(\n    a,\n    b,\n    c,\n    d\n) {\n}",
-        "true":"// function_declaration.multiline.leading_comma: true\nfunction example(\n      a\n    , b\n    , c\n    , d\n) {\n}"
+        "true":"// function_declaration.multiline.leading_comma: true\nfunction example(\n      a\n    , b\n    , c\n    , d\n) {\n}",
+        "false":"// function_declaration.multiline.leading_comma: false\nfunction example(\n    a,\n    b,\n    c,\n    d\n) {\n}"
     },
     "function_declaration.multiline.leading_comma.padding":{
-        "false":"// function_declaration.multiline.leading_comma.padding: false\nfunction example(\n     a\n    ,b\n    ,c\n    ,d\n) {\n}",
-        "true":"// function_declaration.multiline.leading_comma.padding: true\nfunction example(\n      a\n    , b\n    , c\n    , d\n) {\n}"
+        "true":"// function_declaration.multiline.leading_comma.padding: true\nfunction example(\n      a\n    , b\n    , c\n    , d\n) {\n}",
+        "false":"// function_declaration.multiline.leading_comma.padding: false\nfunction example(\n     a\n    ,b\n    ,c\n    ,d\n) {\n}"
     },
     "function_declaration.padding":{
-        "false":"// function_declaration.padding: false\nfunction example(a, b) {\n}",
-        "true":"// function_declaration.padding: true\nfunction example( a, b ) {\n}"
+        "true":"// function_declaration.padding: true\nfunction example( a, b ) {\n}",
+        "false":"// function_declaration.padding: false\nfunction example(a, b) {\n}"
     },
     "indent_size":{
-        "2":"// indent_size: 2\ndo {\n  myFunc();\n}",
-        "4":"// indent_size: 4\ndo {\n    myFunc();\n}"
+        "4":"// indent_size: 4\ndo {\n    myFunc();\n}",
+        "2":"// indent_size: 2\ndo {\n  myFunc();\n}"
     },
     "keywords.block_to_keyword_spacing":{
+        "spaced":"// keywords.block_to_keyword_spacing: \"spaced\"\nif (true) {\n} else {\n}",
         "compact":"// keywords.block_to_keyword_spacing: \"compact\"\nif (true) {\n}else {\n}",
-        "newline":"// keywords.block_to_keyword_spacing: \"newline\"\nif (true) {\n}\nelse {\n}",
-        "spaced":"// keywords.block_to_keyword_spacing: \"spaced\"\nif (true) {\n} else {\n}"
+        "newline":"// keywords.block_to_keyword_spacing: \"newline\"\nif (true) {\n}\nelse {\n}"
     },
     "keywords.empty_group_spacing":{
-        "false":"// keywords.empty_group_spacing: false\nif () {\n}",
-        "true":"// keywords.empty_group_spacing: true\nif ( ) {\n}"
+        "true":"// keywords.empty_group_spacing: true\nif ( ) {\n}",
+        "false":"// keywords.empty_group_spacing: false\nif () {\n}"
     },
     "keywords.group_to_block_spacing":{
+        "spaced":"// keywords.group_to_block_spacing: \"spaced\"\nif (true) {\n}",
         "compact":"// keywords.group_to_block_spacing: \"compact\"\nif (true){\n}",
-        "newline":"// keywords.group_to_block_spacing: \"newline\"\nif (true)\n{\n}",
-        "spaced":"// keywords.group_to_block_spacing: \"spaced\"\nif (true) {\n}"
+        "newline":"// keywords.group_to_block_spacing: \"newline\"\nif (true)\n{\n}"
     },
     "keywords.padding_inside_group":{
-        "false":"// keywords.padding_inside_group: false\nif (true) {\n}",
-        "true":"// keywords.padding_inside_group: true\nif ( true ) {\n}"
+        "true":"// keywords.padding_inside_group: true\nif ( true ) {\n}",
+        "false":"// keywords.padding_inside_group: false\nif (true) {\n}"
     },
     "keywords.spacing_to_block":{
+        "spaced":"// keywords.spacing_to_block: \"spaced\"\ndo {\n}",
         "compact":"// keywords.spacing_to_block: \"compact\"\ndo{\n}",
-        "newline":"// keywords.spacing_to_block: \"newline\"\ndo\n{\n}",
-        "spaced":"// keywords.spacing_to_block: \"spaced\"\ndo {\n}"
+        "newline":"// keywords.spacing_to_block: \"newline\"\ndo\n{\n}"
     },
     "keywords.spacing_to_group":{
-        "false":"// keywords.spacing_to_group: false\nif(true) {\n}",
-        "true":"// keywords.spacing_to_group: true\nif (true) {\n}"
+        "true":"// keywords.spacing_to_group: true\nif (true) {\n}",
+        "false":"// keywords.spacing_to_group: false\nif(true) {\n}"
     },
     "parentheses.padding":{
-        "false":"// parentheses.padding: false\na = (1 + 2);",
-        "true":"// parentheses.padding: true\na = ( 1 + 2 );"
+        "true":"// parentheses.padding: true\na = ( 1 + 2 );",
+        "false":"// parentheses.padding: false\na = (1 + 2);"
     },
     "strings.attributes.quote":{
-        "":"// strings.attributes.quote: \"\"\nhttp url='www.google.com';\nparam name=\"key\";",
+        "single":"// strings.attributes.quote: \"single\"\nhttp url='www.google.com';\nparam name='key';",
         "double":"// strings.attributes.quote: \"double\"\nhttp url=\"www.google.com\";\nparam name=\"key\";",
-        "single":"// strings.attributes.quote: \"single\"\nhttp url='www.google.com';\nparam name='key';"
+        "":"// strings.attributes.quote: \"\"\nhttp url='www.google.com';\nparam name=\"key\";"
     },
     "strings.quote":{
-        "":"// strings.quote: \"\"\na = \"One\";\nb = 'Two';",
+        "single":"// strings.quote: \"single\"\na = 'One';\nb = 'Two';",
         "double":"// strings.quote: \"double\"\na = \"One\";\nb = \"Two\";",
-        "single":"// strings.quote: \"single\"\na = 'One';\nb = 'Two';"
+        "":"// strings.quote: \"\"\na = \"One\";\nb = 'Two';"
     },
     "struct.empty_padding":{
-        "false":"// struct.empty_padding: false\nmyStruct = {};",
-        "true":"// struct.empty_padding: true\nmyStruct = { };"
+        "true":"// struct.empty_padding: true\nmyStruct = { };",
+        "false":"// struct.empty_padding: false\nmyStruct = {};"
     },
     "struct.multiline.leading_comma":{
-        "false":"// struct.multiline.leading_comma: false\nmyStruct = {\n    a: 1,\n    b: 2,\n    c: 3,\n    d: 4\n};",
-        "true":"// struct.multiline.leading_comma: true\nmyStruct = {\n      a: 1\n    , b: 2\n    , c: 3\n    , d: 4\n};"
+        "true":"// struct.multiline.leading_comma: true\nmyStruct = {\n      a: 1\n    , b: 2\n    , c: 3\n    , d: 4\n};",
+        "false":"// struct.multiline.leading_comma: false\nmyStruct = {\n    a: 1,\n    b: 2,\n    c: 3,\n    d: 4\n};"
     },
     "struct.multiline.leading_comma.padding":{
-        "false":"// struct.multiline.leading_comma.padding: false\nmyStruct = {\n     a: 1\n    ,b: 2\n    ,c: 3\n    ,d: 4\n};",
-        "true":"// struct.multiline.leading_comma.padding: true\nmyStruct = {\n      a: 1\n    , b: 2\n    , c: 3\n    , d: 4\n};"
+        "true":"// struct.multiline.leading_comma.padding: true\nmyStruct = {\n      a: 1\n    , b: 2\n    , c: 3\n    , d: 4\n};",
+        "false":"// struct.multiline.leading_comma.padding: false\nmyStruct = {\n     a: 1\n    ,b: 2\n    ,c: 3\n    ,d: 4\n};"
     },
     "struct.padding":{
-        "false":"// struct.padding: false\nmyStruct = {a: 1, b: 2};",
-        "true":"// struct.padding: true\nmyStruct = { a: 1, b: 2 };"
+        "true":"// struct.padding: true\nmyStruct = { a: 1, b: 2 };",
+        "false":"// struct.padding: false\nmyStruct = {a: 1, b: 2};"
     },
     "struct.separator":{
-        " : ":"// struct.separator: \" : \"\nmyStruct = {a : 1, b : 2};",
-        " = ":"// struct.separator: \" = \"\nmyStruct = {a = 1, b = 2};",
         ": ":"// struct.separator: \": \"\nmyStruct = {a: 1, b: 2};",
+        " = ":"// struct.separator: \" = \"\nmyStruct = {a = 1, b = 2};",
+        " : ":"// struct.separator: \" : \"\nmyStruct = {a : 1, b : 2};",
         "=":"// struct.separator: \"=\"\nmyStruct = {a=1, b=2};"
     }
 }

--- a/reference.md
+++ b/reference.md
@@ -9,12 +9,12 @@ Default: **false**
 When true, cfformat will attempt to align consecutive variable assignments, named function call arguments, and struct key value pairs.
 
 ```cfc
-// alignment.consecutive.assignments: true
-var a  = 1;
-var ab = 2;
-
 // alignment.consecutive.assignments: false
 var a = 1;
+var ab = 2;
+
+// alignment.consecutive.assignments: true
+var a  = 1;
 var ab = 2;
 ```
 
@@ -27,12 +27,12 @@ Default: **false**
 When true, cfformat will attempt to align the attributes of consecutive params.
 
 ```cfc
-// alignment.consecutive.params: true
-param name="a"       type="string";
-param name="abcdefg" type="string";
-
 // alignment.consecutive.params: false
 param name="a" type="string";
+param name="abcdefg" type="string";
+
+// alignment.consecutive.params: true
+param name="a"       type="string";
 param name="abcdefg" type="string";
 ```
 
@@ -45,13 +45,13 @@ Default: **false**
 When true, cfformat will attempt to align the attributes of consecutive properties.
 
 ```cfc
-// alignment.consecutive.properties: true
-property name="requestService" inject="coldbox:requestService";
-property name="log"            inject="logbox:logger:{this}";
-
 // alignment.consecutive.properties: false
 property name="requestService" inject="coldbox:requestService";
 property name="log" inject="logbox:logger:{this}";
+
+// alignment.consecutive.properties: true
+property name="requestService" inject="coldbox:requestService";
+property name="log"            inject="logbox:logger:{this}";
 ```
 
 ## array.empty_padding
@@ -63,11 +63,11 @@ Default: **false**
 When true, empty arrays are padded with a space.
 
 ```cfc
-// array.empty_padding: true
-myArray = [ ];
-
 // array.empty_padding: false
 myArray = [];
+
+// array.empty_padding: true
+myArray = [ ];
 ```
 
 ## array.multiline.element_count
@@ -88,20 +88,20 @@ Default: **false**
 Whether to use a leading comma when an array is printed on multiple lines.
 
 ```cfc
-// array.multiline.leading_comma: true
-myArray = [
-      1
-    , 2
-    , 3
-    , 4
-];
-
 // array.multiline.leading_comma: false
 myArray = [
     1,
     2,
     3,
     4
+];
+
+// array.multiline.leading_comma: true
+myArray = [
+      1
+    , 2
+    , 3
+    , 4
 ];
 ```
 
@@ -114,20 +114,20 @@ Default: **true**
 Whether to insert a space after leading commas when an array is printed on multiple lines.
 
 ```cfc
-// array.multiline.leading_comma.padding: true
-myArray = [
-      1
-    , 2
-    , 3
-    , 4
-];
-
 // array.multiline.leading_comma.padding: false
 myArray = [
      1
     ,2
     ,3
     ,4
+];
+
+// array.multiline.leading_comma.padding: true
+myArray = [
+      1
+    , 2
+    , 3
+    , 4
 ];
 ```
 
@@ -149,11 +149,11 @@ Default: **false**
 When true, non-empty arrays are padded with spaces.
 
 ```cfc
-// array.padding: true
-myArray = [ 1, 2 ];
-
 // array.padding: false
 myArray = [1, 2];
+
+// array.padding: true
+myArray = [ 1, 2 ];
 ```
 
 ## binary_operators.padding
@@ -165,11 +165,11 @@ Default: **true**
 Whether to pad binary operators with spaces.
 
 ```cfc
-// binary_operators.padding: true
-a = 1 + 2;
-
 // binary_operators.padding: false
 a=1+2;
+
+// binary_operators.padding: true
+a = 1 + 2;
 ```
 
 ## brackets.padding
@@ -181,11 +181,11 @@ Default: **false**
 When true, bracketed accessors are padded with spaces.
 
 ```cfc
-// brackets.padding: true
-a[ 'mykey' ][ 1 ] = 7;
-
 // brackets.padding: false
 a['mykey'][1] = 7;
+
+// brackets.padding: true
+a[ 'mykey' ][ 1 ] = 7;
 ```
 
 ## comment.asterisks
@@ -197,6 +197,13 @@ Values: [**"align"**, "indent", ""]
 When enabled, if every line after the first of a block comment starts with a `*`, they will be aligned. Setting this to an empty string means no alignment will be done.
 
 ```cfc
+// comment.asterisks: ""
+{
+    /**
+      * a comment
+    */
+}
+
 // comment.asterisks: "align"
 {
     /**
@@ -210,13 +217,6 @@ When enabled, if every line after the first of a block comment starts with a `*`
     * a comment
     */
 }
-
-// comment.asterisks: ""
-{
-    /**
-      * a comment
-    */
-}
 ```
 
 ## for_loop_semicolons.padding
@@ -228,12 +228,12 @@ Default: **true**
 When true, insert a space after for loop semicolons.
 
 ```cfc
-// for_loop_semicolons.padding: true
-for (var i = 0; i < 10; i++) {
-}
-
 // for_loop_semicolons.padding: false
 for (var i = 0;i < 10;i++) {
+}
+
+// for_loop_semicolons.padding: true
+for (var i = 0; i < 10; i++) {
 }
 ```
 
@@ -246,12 +246,12 @@ Default: **false**
 When true, pad anonymous function declarations that have no parameters with a space.
 
 ```cfc
-// function_anonymous.empty_padding: true
-function( ) {
-}
-
 // function_anonymous.empty_padding: false
 function() {
+}
+
+// function_anonymous.empty_padding: true
+function( ) {
 }
 ```
 
@@ -264,10 +264,6 @@ Values: [**"spaced"**, "compact", "newline"]
 How to space from the anonymous function parameters to the function block.
 
 ```cfc
-// function_anonymous.group_to_block_spacing: "spaced"
-function() {
-}
-
 // function_anonymous.group_to_block_spacing: "compact"
 function(){
 }
@@ -275,6 +271,10 @@ function(){
 // function_anonymous.group_to_block_spacing: "newline"
 function()
 {
+}
+
+// function_anonymous.group_to_block_spacing: "spaced"
+function() {
 }
 ```
 
@@ -296,21 +296,21 @@ Default: **false**
 Whether to use a leading comma when anonymous function declaration parameters are printed on multiple lines.
 
 ```cfc
-// function_anonymous.multiline.leading_comma: true
-function(
-      a
-    , b
-    , c
-    , d
-) {
-}
-
 // function_anonymous.multiline.leading_comma: false
 function(
     a,
     b,
     c,
     d
+) {
+}
+
+// function_anonymous.multiline.leading_comma: true
+function(
+      a
+    , b
+    , c
+    , d
 ) {
 }
 ```
@@ -324,21 +324,21 @@ Default: **true**
 Whether to insert a space after leading commas when anonymous function declaration parameters are printed on multiple lines.
 
 ```cfc
-// function_anonymous.multiline.leading_comma.padding: true
-function(
-      a
-    , b
-    , c
-    , d
-) {
-}
-
 // function_anonymous.multiline.leading_comma.padding: false
 function(
      a
     ,b
     ,c
     ,d
+) {
+}
+
+// function_anonymous.multiline.leading_comma.padding: true
+function(
+      a
+    , b
+    , c
+    , d
 ) {
 }
 ```
@@ -361,12 +361,12 @@ Default: **false**
 Whether to pad non-empty anonymous function declarations with spaces.
 
 ```cfc
-// function_anonymous.padding: true
-function( a, b ) {
-}
-
 // function_anonymous.padding: false
 function(a, b) {
+}
+
+// function_anonymous.padding: true
+function( a, b ) {
 }
 ```
 
@@ -379,14 +379,14 @@ Values: [**"cfdocs"**, "pascal", ""]
 Formats builtin function call casing. The default is to match cfdocs.org data. An alternative is to always capitalize the first letter (pascal). Set this setting to an empty string to leave casing as is.
 
 ```cfc
+// function_call.casing.builtin: ""
+ARRAYAPPEND(myarray, 1);
+
 // function_call.casing.builtin: "cfdocs"
 arrayAppend(myarray, 1);
 
 // function_call.casing.builtin: "pascal"
 ArrayAppend(myarray, 1);
-
-// function_call.casing.builtin: ""
-ARRAYAPPEND(myarray, 1);
 ```
 
 ## function_call.casing.userdefined
@@ -417,11 +417,11 @@ Default: **false**
 When true, function calls with no arguments are padded with a space.
 
 ```cfc
-// function_call.empty_padding: true
-myFunc( );
-
 // function_call.empty_padding: false
 myFunc();
+
+// function_call.empty_padding: true
+myFunc( );
 ```
 
 ## function_call.multiline.element_count
@@ -442,20 +442,20 @@ Default: **false**
 Whether to use a leading comma when function call arguments are printed on multiple lines.
 
 ```cfc
-// function_call.multiline.leading_comma: true
-myFunc(
-      1
-    , 2
-    , 3
-    , 4
-);
-
 // function_call.multiline.leading_comma: false
 myFunc(
     1,
     2,
     3,
     4
+);
+
+// function_call.multiline.leading_comma: true
+myFunc(
+      1
+    , 2
+    , 3
+    , 4
 );
 ```
 
@@ -468,20 +468,20 @@ Default: **true**
 Whether to insert a space after leading commas when function call arguments are printed on multiple lines.
 
 ```cfc
-// function_call.multiline.leading_comma.padding: true
-myFunc(
-      1
-    , 2
-    , 3
-    , 4
-);
-
 // function_call.multiline.leading_comma.padding: false
 myFunc(
      1
     ,2
     ,3
     ,4
+);
+
+// function_call.multiline.leading_comma.padding: true
+myFunc(
+      1
+    , 2
+    , 3
+    , 4
 );
 ```
 
@@ -503,11 +503,11 @@ Default: **false**
 Whether to pad function call arguments with spaces.
 
 ```cfc
-// function_call.padding: true
-myFunc( 1, 2 );
-
 // function_call.padding: false
 myFunc(1, 2);
+
+// function_call.padding: true
+myFunc( 1, 2 );
 ```
 
 ## function_declaration.empty_padding
@@ -519,12 +519,12 @@ Default: **false**
 When true, pad function declarations that have no parameters with a space.
 
 ```cfc
-// function_declaration.empty_padding: true
-function example( ) {
-}
-
 // function_declaration.empty_padding: false
 function example() {
+}
+
+// function_declaration.empty_padding: true
+function example( ) {
 }
 ```
 
@@ -537,10 +537,6 @@ Values: [**"spaced"**, "compact", "newline"]
 How to space from the function parameters to the function block.
 
 ```cfc
-// function_declaration.group_to_block_spacing: "spaced"
-function example() {
-}
-
 // function_declaration.group_to_block_spacing: "compact"
 function example(){
 }
@@ -548,6 +544,10 @@ function example(){
 // function_declaration.group_to_block_spacing: "newline"
 function example()
 {
+}
+
+// function_declaration.group_to_block_spacing: "spaced"
+function example() {
 }
 ```
 
@@ -569,21 +569,21 @@ Default: **false**
 Whether to use a leading comma when function declaration parameters are printed on multiple lines.
 
 ```cfc
-// function_declaration.multiline.leading_comma: true
-function example(
-      a
-    , b
-    , c
-    , d
-) {
-}
-
 // function_declaration.multiline.leading_comma: false
 function example(
     a,
     b,
     c,
     d
+) {
+}
+
+// function_declaration.multiline.leading_comma: true
+function example(
+      a
+    , b
+    , c
+    , d
 ) {
 }
 ```
@@ -597,21 +597,21 @@ Default: **true**
 Whether to insert a space after leading commas when function declaration parameters are printed on multiple lines.
 
 ```cfc
-// function_declaration.multiline.leading_comma.padding: true
-function example(
-      a
-    , b
-    , c
-    , d
-) {
-}
-
 // function_declaration.multiline.leading_comma.padding: false
 function example(
      a
     ,b
     ,c
     ,d
+) {
+}
+
+// function_declaration.multiline.leading_comma.padding: true
+function example(
+      a
+    , b
+    , c
+    , d
 ) {
 }
 ```
@@ -634,12 +634,12 @@ Default: **false**
 Whether to pad non-empty function declarations with spaces.
 
 ```cfc
-// function_declaration.padding: true
-function example( a, b ) {
-}
-
 // function_declaration.padding: false
 function example(a, b) {
+}
+
+// function_declaration.padding: true
+function example( a, b ) {
 }
 ```
 
@@ -652,14 +652,14 @@ Default: **4**
 Each indent level or tab is equivalent to this many spaces.
 
 ```cfc
-// indent_size: 4
-do {
-    myFunc();
-}
-
 // indent_size: 2
 do {
   myFunc();
+}
+
+// indent_size: 4
+do {
+    myFunc();
 }
 ```
 
@@ -672,11 +672,6 @@ Values: [**"spaced"**, "compact", "newline"]
 Spacing for keywords following a block.
 
 ```cfc
-// keywords.block_to_keyword_spacing: "spaced"
-if (true) {
-} else {
-}
-
 // keywords.block_to_keyword_spacing: "compact"
 if (true) {
 }else {
@@ -686,6 +681,11 @@ if (true) {
 if (true) {
 }
 else {
+}
+
+// keywords.block_to_keyword_spacing: "spaced"
+if (true) {
+} else {
 }
 ```
 
@@ -698,12 +698,12 @@ Default: **false**
 Whether to pad empty keyword groups.
 
 ```cfc
-// keywords.empty_group_spacing: true
-if ( ) {
-}
-
 // keywords.empty_group_spacing: false
 if () {
+}
+
+// keywords.empty_group_spacing: true
+if ( ) {
 }
 ```
 
@@ -716,10 +716,6 @@ Values: [**"spaced"**, "compact", "newline"]
 Spacing from a keyword group to the following block.
 
 ```cfc
-// keywords.group_to_block_spacing: "spaced"
-if (true) {
-}
-
 // keywords.group_to_block_spacing: "compact"
 if (true){
 }
@@ -727,6 +723,10 @@ if (true){
 // keywords.group_to_block_spacing: "newline"
 if (true)
 {
+}
+
+// keywords.group_to_block_spacing: "spaced"
+if (true) {
 }
 ```
 
@@ -739,12 +739,12 @@ Default: **false**
 Whether to pad inside non-empty keyword groups.
 
 ```cfc
-// keywords.padding_inside_group: true
-if ( true ) {
-}
-
 // keywords.padding_inside_group: false
 if (true) {
+}
+
+// keywords.padding_inside_group: true
+if ( true ) {
 }
 ```
 
@@ -757,10 +757,6 @@ Values: [**"spaced"**, "compact", "newline"]
 Spacing from a keyword to the following block.
 
 ```cfc
-// keywords.spacing_to_block: "spaced"
-do {
-}
-
 // keywords.spacing_to_block: "compact"
 do{
 }
@@ -768,6 +764,10 @@ do{
 // keywords.spacing_to_block: "newline"
 do
 {
+}
+
+// keywords.spacing_to_block: "spaced"
+do {
 }
 ```
 
@@ -780,12 +780,12 @@ Default: **true**
 Whether to space a keyword from following group.
 
 ```cfc
-// keywords.spacing_to_group: true
-if (true) {
-}
-
 // keywords.spacing_to_group: false
 if(true) {
+}
+
+// keywords.spacing_to_group: true
+if (true) {
 }
 ```
 
@@ -825,11 +825,11 @@ Default: **false**
 Whether to pad the contents of a group.
 
 ```cfc
-// parentheses.padding: true
-a = ( 1 + 2 );
-
 // parentheses.padding: false
 a = (1 + 2);
+
+// parentheses.padding: true
+a = ( 1 + 2 );
 ```
 
 ## strings.attributes.quote
@@ -841,17 +841,17 @@ Values: ["single", **"double"**, ""]
 Whether to use a single or double quote for attribute values. If set to an empty string, leaves attribute value quotes as they are found.
 
 ```cfc
-// strings.attributes.quote: "single"
+// strings.attributes.quote: ""
 http url='www.google.com';
-param name='key';
+param name="key";
 
 // strings.attributes.quote: "double"
 http url="www.google.com";
 param name="key";
 
-// strings.attributes.quote: ""
+// strings.attributes.quote: "single"
 http url='www.google.com';
-param name="key";
+param name='key';
 ```
 
 ## strings.quote
@@ -863,16 +863,16 @@ Values: [**"single"**, "double", ""]
 Whether to use a single or double quote for strings. If set to an empty string, leaves string quotes as they are found.
 
 ```cfc
-// strings.quote: "single"
-a = 'One';
+// strings.quote: ""
+a = "One";
 b = 'Two';
 
 // strings.quote: "double"
 a = "One";
 b = "Two";
 
-// strings.quote: ""
-a = "One";
+// strings.quote: "single"
+a = 'One';
 b = 'Two';
 ```
 
@@ -885,11 +885,11 @@ Default: **false**
 When true, non-empty structs are padded with spaces.
 
 ```cfc
-// struct.empty_padding: true
-myStruct = { };
-
 // struct.empty_padding: false
 myStruct = {};
+
+// struct.empty_padding: true
+myStruct = { };
 ```
 
 ## struct.multiline.element_count
@@ -910,20 +910,20 @@ Default: **false**
 Whether to use a leading comma when an struct is printed on multiple lines.
 
 ```cfc
-// struct.multiline.leading_comma: true
-myStruct = {
-      a: 1
-    , b: 2
-    , c: 3
-    , d: 4
-};
-
 // struct.multiline.leading_comma: false
 myStruct = {
     a: 1,
     b: 2,
     c: 3,
     d: 4
+};
+
+// struct.multiline.leading_comma: true
+myStruct = {
+      a: 1
+    , b: 2
+    , c: 3
+    , d: 4
 };
 ```
 
@@ -936,20 +936,20 @@ Default: **true**
 Whether to insert a space after leading commas when an struct is printed on multiple lines.
 
 ```cfc
-// struct.multiline.leading_comma.padding: true
-myStruct = {
-      a: 1
-    , b: 2
-    , c: 3
-    , d: 4
-};
-
 // struct.multiline.leading_comma.padding: false
 myStruct = {
      a: 1
     ,b: 2
     ,c: 3
     ,d: 4
+};
+
+// struct.multiline.leading_comma.padding: true
+myStruct = {
+      a: 1
+    , b: 2
+    , c: 3
+    , d: 4
 };
 ```
 
@@ -971,11 +971,11 @@ Default: **false**
 Whether to pad non-empty structs with spaces.
 
 ```cfc
-// struct.padding: true
-myStruct = { a: 1, b: 2 };
-
 // struct.padding: false
 myStruct = {a: 1, b: 2};
+
+// struct.padding: true
+myStruct = { a: 1, b: 2 };
 ```
 
 ## struct.separator
@@ -985,14 +985,14 @@ Default: **": "**
 The key value separator to use in structs - it must contain either a single `:` or `=` and be no more than 3 characters in length.
 
 ```cfc
-// struct.separator: ": "
-myStruct = {a: 1, b: 2};
+// struct.separator: " : "
+myStruct = {a : 1, b : 2};
 
 // struct.separator: " = "
 myStruct = {a = 1, b = 2};
 
-// struct.separator: " : "
-myStruct = {a : 1, b : 2};
+// struct.separator: ": "
+myStruct = {a: 1, b: 2};
 
 // struct.separator: "="
 myStruct = {a=1, b=2};


### PR DESCRIPTION
This pull request adds a settings wizard as discussed in #19 

Here's how it looks in action: https://www.dropbox.com/s/3mukp3yu4ou4x4v/cfformat%20demo.mp4?dl=0

The **other** thing this PR has is a re-invisioned idea of how the command namespacing could work.  Most of the files are placeholders, but the idea is to break out parts of the current `cfformat` command that are controlled via flags to different nested commands.

I can obviously revert the command namespacing changes, but I think it's worth talking about as this project keeps growing.