### PR TITLE
fix cfformat settings show

### DIFF
--- a/commands/cfformat/settings/show.cfc
+++ b/commands/cfformat/settings/show.cfc
@@ -20,7 +20,7 @@ component accessors="true" {
      * @settingsPath path to a JSON settings file
      */
     function run(string path = '', string settingsPath = '') {
-        var pathData = cfformatUtils.resolveFormatPath(path);
+        var pathData = cfformatUtils.resolveFormatPath(path,false);
 
         if (path.len() && !pathData.filePaths.len()) {
             print.redLine(path & ' is not a valid file or directory.');


### PR DESCRIPTION
fixes error for command:
`cfformat settings show`

```
variable [ALLOWCFM] doesn't exist                                                                                                      

/modules/commandbox-cfformat/models/CFFormatUtils.cfc: line 34
32:         }
33: 
34:         return {pathType: pathType, filePaths: resolveFilePaths(fullPath, pathType, allowCfm)};
35:     }
36: 
called from /modules/commandbox-cfformat/commands/cfformat/settings/show.cfc: line 23
called from /system/services/CommandService.cfc: line 343
called from /system/services/CommandService.cfc: line 139
called from /system/Shell.cfc: line 771
called from /system/Shell.cfc: line 591
called from /system/Bootstrap.cfm: line 154
```
