### PR TITLE
Fix API method call on Watcher (delayMS should have been withDelay)

### DIFF
--- a/commands/cfformat/watch.cfc
+++ b/commands/cfformat/watch.cfc
@@ -46,7 +46,7 @@ component accessors="true" extends="run" aliases="" {
 
         this.watch()
             .paths(argumentCollection = paths)
-            .delayMS(arguments.pollDelay)
+            .withDelay(arguments.pollDelay)
             .onChange((files) => {
                 var allFiles = files.added
                     .append(files.changed, true)


### PR DESCRIPTION
Whoops! I used a non-existent method when trying to set the polling delay in #121.