### PR TITLE
Disable code coverage measurement.

### DIFF
--- a/tests/index.cfm
+++ b/tests/index.cfm
@@ -12,7 +12,7 @@ cfexecute(
     variable='fileArray'
 );
 
-testbox = new testbox.system.Testbox();
+testbox = new testbox.system.Testbox(options: { coverage: { enabled: false }});
 param name="url.reporter" default="simple";
 param name="url.directory" default="tests.specs";
 args = {reporter: url.reporter, directory: url.directory};


### PR DESCRIPTION
Coverage measurement breaks (on one of my workstations) due to some invalid
.cfc files in the test fixtures.

I tried configuring code coverage correctly, and I was able to, but the coverage
numbers are way off and I don't have time to troubleshoot why they're not
accurate.