### PR TITLE
Configure code coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 testbox/
+tests/coverage/
 tests/json/
 out.cfc

--- a/box.json
+++ b/box.json
@@ -3,6 +3,7 @@
     "bugs":"https://github.com/jcberquist/commandbox-cfformat/issues",
     "cftokens":"v0.16.7",
     "devDependencies":{
+        "commandbox-fusionreactor":"^4.0.9",
         "testbox":"^4.0.0"
     },
     "documentation":"https://github.com/jcberquist/commandbox-cfformat",

--- a/tests/index.cfm
+++ b/tests/index.cfm
@@ -12,7 +12,16 @@ cfexecute(
     variable='fileArray'
 );
 
-testbox = new testbox.system.Testbox();
+testbox = new testbox.system.Testbox(
+    options: {
+        coverage: {
+            blacklist: "tests,testbox",
+            browser: {
+                outputDir: "#ExpandPath('.')#/coverage"
+            }
+        }
+    }
+);
 param name="url.reporter" default="simple";
 param name="url.directory" default="tests.specs";
 args = {reporter: url.reporter, directory: url.directory};


### PR DESCRIPTION
There are at least two problems with the coverage reporting.
1. The overall code coverage number is totally inaccurate in testbox's current release. It's showing the coverage percentage of a single file instead of an aggregate. This is fixed already in their `master` branch, but an updated version has not been released.
2. There are many files showing 0% code coverage which are almost certainly exercised by the test suite. I don't know why this is happening, but we've seen similar problems with testbox/FusionReactor's measurements in other projects.