### PR TITLE
Add ability to format only staged files in Git

### DIFF
--- a/commands/cfformat/run.cfc
+++ b/commands/cfformat/run.cfc
@@ -22,7 +22,6 @@ component accessors="true" aliases="fmt" {
      * @overwrite overwrite file in place
      * @timeit print the time formatting took to the console
      * @cfm format cfm files as well as cfc - use with caution, preferably on pure CFML cfm files
-     * @staged Flag to run against staged files in git only. Overwrites `path` when used. Changes will also be staged.
      */
     function run(
         string path = '',
@@ -54,10 +53,6 @@ component accessors="true" aliases="fmt" {
                 overwrite,
                 timeit
             );
-        }
-
-        if (arguments.staged) {
-            commitFormattedStagedFiles(listToArray(arguments.path));
         }
     }
 


### PR DESCRIPTION
This introduces a new namespace as well as a new command: `cfformat git staged`. This command will run the formatting rules against any staged files for the git project.  The directory used is the current directory but can be overridden.  Any files that are formatted are staged at the end of running the command.

This command is very useful in a project where you want to ensure formatting for all files but 1) don't want to or forgot to run `cfformat watch` and 2) don't want to format the entire repo each time you are ready to commit.